### PR TITLE
Short UUID custom parse str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "short-uuid"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "short-uuid"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Radim Höfer"]
 categories = ["data-structures"]
 description = "A library to generate and parse short uuids"
 documentation = "https://docs.rs/short-uuid"
-metadata = "0.1.2"
+metadata = "0.1.3"
 
 keywords = ["uuid", "short-uuid"]
 
@@ -40,4 +40,3 @@ features = ["v4"]
 
 [dev-dependencies]
 criterion = "0.5.1"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,12 @@ impl ShortUuidCustom {
         short_uuid_str: &str,
         translator: &CustomTranslator,
     ) -> Result<Self, InvalidShortUuid> {
+        let expected_len = 22;
+
+        if short_uuid_str.len() != expected_len {
+            return Err(InvalidShortUuid);
+        };
+
         let byte_vector: Vec<u8> = short_uuid_str.as_bytes().to_vec();
 
         let result_string = translator

--- a/tests/parse_str_custom.rs
+++ b/tests/parse_str_custom.rs
@@ -40,4 +40,15 @@ mod tests {
 
         dbg!(&from_short);
     }
+
+    #[test]
+    // Test with invalid short uuid
+    fn parse_str_success_error() {
+        let custom_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let short_string = "mhvXdrZ";
+        let translator = CustomTranslator::new(custom_alphabet).unwrap();
+        let short_uuid = ShortUuidCustom::parse_str(short_string, &translator)
+            .expect_err("Test should have failed");
+        dbg!(&short_uuid);
+    }
 }


### PR DESCRIPTION
I noticed `ShortUuidCustom::parse_str` was missing the short_uuid len check found in the `ShortUuid::parse_str`
https://github.com/radim10/short-uuid/blob/master/src/lib.rs#L208-L228