### PR TITLE
fix/parse_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "short-uuid"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "short-uuid"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Radim Höfer"]
 categories = ["data-structures"]
 description = "A library to generate and parse short uuids"
 documentation = "https://docs.rs/short-uuid"
-metadata = "0.1.3"
+metadata = "0.1.4"
 
 keywords = ["uuid", "short-uuid"]
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ or add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-short-uuid = "0.1.0"
+short-uuid = "0.1.4"
 ```
 
 ### Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,12 +290,6 @@ impl ShortUuidCustom {
         short_uuid_str: &str,
         translator: &CustomTranslator,
     ) -> Result<Self, InvalidShortUuid> {
-        let expected_len = 22;
-
-        if short_uuid_str.len() != expected_len {
-            return Err(InvalidShortUuid);
-        };
-
         let byte_vector: Vec<u8> = short_uuid_str.as_bytes().to_vec();
 
         let result_string = translator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! short-uuid = "0.1.0"
+//! short-uuid = "0.1.4"
 //! ```
 //! ### Examples
 //!

--- a/tests/cookie_base_90.rs
+++ b/tests/cookie_base_90.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+mod tests {
+    use short_uuid::{CustomTranslator, ShortUuidCustom};
+
+    #[test]
+    fn cookie_base_90() {
+        let translator = CustomTranslator::new(short_uuid::COOKIE_BASE_90).unwrap();
+        let orig_uuid_str = "420e04de-4f06-4e3b-8718-9f6ede92ea9e";
+
+        let short = ShortUuidCustom::from_uuid_str(orig_uuid_str, &translator).unwrap();
+        let short_uuid_str = short.to_string();
+
+        let short2 = ShortUuidCustom::parse_str(&short_uuid_str, &translator).unwrap();
+        let string2 = short2.to_uuid(&translator).unwrap();
+
+        assert_eq!(string2.to_string(), orig_uuid_str);
+    }
+}


### PR DESCRIPTION
# Changes
This PR includes several updates:

1. **Fix**: Removed fixed length validation (22 chars) from `ShortUuidCustom::parse_str` to correctly support different alphabet lengths
2. **Test**: Added new test file `tests/cookie_base_90.rs` to validate COOKIE_BASE_90 alphabet functionality
3. **Version**: Bumped package version from 0.1.3 to 0.1.4
4. **Docs**: Updated version numbers in documentation (README.md and lib.rs)