### PR TITLE
Add Hash derive impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,11 +154,11 @@ type UuidError = uuid::Error;
 pub type Bytes = Vec<u8>;
 
 /// Shortened UUID
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ShortUuid(Bytes);
 
 /// Shortened UUID using custom alphabet
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ShortUuidCustom(Bytes);
 
 /// Custom alphabet used for short uuid


### PR DESCRIPTION
Hey there. Thanks for this library.

I was hoping to use `ShortUuid` for a simple project, but was surprised that it doesn't impl `Hash`, [like `Uuid` does](https://docs.rs/uuid/1.19.0/uuid/struct.Uuid.html#impl-Hash-for-Uuid).