### PR TITLE
GitHub workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,10 @@ name: Rust
 
 on:
   push:
-#    paths:
-#      - 'src/**'
-#      - 'tests/**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/**'
   pull_request:
     branches: ['master']
     paths:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    paths:
-      - 'src/**'
-      - 'tests/**'
+#    paths:
+#      - 'src/**'
+#      - 'tests/**'
   pull_request:
     branches: ['master']
     paths:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: ['master']
     paths:
-      - '../../src/**'
-      - '../../tests/**'
+      - 'src/**'
+      - 'tests/**'
   pull_request:
     branches: ['master']
     paths:
-      - '../../src/**'
-      - '../../tests/**'
+      - 'src/**'
+      - 'tests/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
+      - '.github/workflows/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,6 @@ name: Rust
 
 on:
   push:
-    branches: ['master']
     paths:
       - 'src/**'
       - 'tests/**'
@@ -20,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
* Changed the path filters to work on the current layout of the project and also run when the GitHub Workflow file changes.
* Removed the branch filtering so a contributor working on a forked repository can get the results of the workflows before sending a pr.

The tests are currently failing as also reported in #11